### PR TITLE
Create CLIP NOTES SEMI notes action equivalent of CLIP SEMI

### DIFF
--- a/ClyphX/ClyphXClipActions.py
+++ b/ClyphX/ClyphXClipActions.py
@@ -627,7 +627,9 @@ class ClyphXClipActions(ControlSurfaceComponent):
                 self.do_note_crescendo(clip, note_data['args'], note_data['notes_to_edit'], note_data['other_notes'])
             elif note_data['args'].startswith('VELO'):
                 self.do_note_velo_adjustment(clip, note_data['args'], note_data['notes_to_edit'], note_data['other_notes'])
-                
+            elif note_data['args'].startswith('SEMI'):
+                self.do_note_action_pitch_adjustment(clip, note_data['args'], note_data['notes_to_edit'], note_data['other_notes'])
+
             
     def set_notes_on_off(self, clip, args, notes_to_edit, other_notes): 
         """ Toggles or turns note mute on/off """
@@ -657,7 +659,28 @@ class ClyphXClipActions(ControlSurfaceComponent):
                     edited_notes.append((new_pitch, n[1], n[2], n[3], n[4]))
             if edited_notes:
                 self.write_all_notes(clip, edited_notes, note_data['other_notes'])
-                        
+
+
+    def do_note_action_pitch_adjustment(self, clip, args, notes_to_edit, other_notes): 
+        """ Adjust note pitch. Like do_note_pitch_adjustment, but a note action"""
+        # Also supports specifying specific notes instead of relative notes.
+        edited_notes = []
+        args = args.replace('SEMI ', '')
+        args = args.strip()
+        for n in notes_to_edit:
+            if args.startswith(('<', '>')):
+                factor = self._parent.get_adjustment_factor(args)
+                new_pitch = n[0] + factor
+            else:
+                (new_pitch, unused) = self.get_note_range(args)
+            if not new_pitch in range (128):
+                edited_notes = []
+                return()
+            else:
+                edited_notes.append((new_pitch, n[1], n[2], n[3], n[4])) 
+        if edited_notes:
+            self.write_all_notes(clip, edited_notes, other_notes)
+
             
     def do_note_gate_adjustment(self, clip, args, notes_to_edit, other_notes): 
         """ Adjust note gate """

--- a/reference.md
+++ b/reference.md
@@ -344,6 +344,9 @@ You can specify both a pitch (or pitch range) and a position (or position range)
 | CLIP NOTES REV | Reverse the position of Notes|  -
 | CLIP NOTES SCRN | Scramble the pitches of Notes while maintaining rhythm | -
 | CLIP NOTES SCRP | Scramble the position of Notes while maintaining pitches |  -
+| CLIP NOTES SEMI < or > | Dec/Inc Notes pitch by 1 semitone | CLIP NOTES SEMI <, CLIP NOTESC3 SEMI >
+| CLIP NOTES SEMI <x or >x | Dec/Inc Notes pitch by x semitones | CLIP NOTES SEMI <x, CLIP NOTESC3 SEMI >x
+| CLIP NOTES SEMI x | Set each note pitch to the named note | CLIP NOTESC3 SEMI C#3
 | CLIP NOTES SPLIT | Split each Note into two equally sized Notes |  -
 | CLIP NOTES VELO x | x is the Note velocity to set |  CLIP NOTES VELO 64, CLIP NOTES VELO 127
 | CLIP NOTES VELO < or > | Dec/Inc the velocity of Notes by increment of 1 |  CLIP NOTES VELO <, CLIP NOTES VELO >


### PR DESCRIPTION
It can be useful to reassign specific midi notes in a clip. CLIP SEMI already exists, but that modifies all notes in a clip. That is fine for transposing an entire clip, but does not allow restricting to a subset of notes.

CLIP NOTES already supports a lot of individual note modifications such as velocity and duration, but does not support pitch modification.

One use case is swapping Drum Rack assignments. For example, if I currently have a sample @ C3, and I'm reassigning it to C4, I can run `1/CLIP NOTESC3 SEMI >12` or `1/CLIP NOTESC3 SEMI C4` to move just the C3 notes in the selected clip.

Just like the other existing CLIP NOTES actions, this triggers a warning in Ableton 11. (https://github.com/ldrolez/clyphx-live11/issues/5)