### PR TITLE
Fix user control actions being truncated at the first `=`

### DIFF
--- a/ClyphX/ClyphXTriggers.py
+++ b/ClyphX/ClyphXTriggers.py
@@ -129,7 +129,7 @@ class ClyphXControlComponent(ControlSurfaceComponent):
             ctrl_num = None
             on_action = None
             off_action = None
-            d = d.split('=')
+            d = d.split('=', 1)
             ctrl_name = d[0].strip()
             new_ctrl_data = d[1].split(',')
             try:


### PR DESCRIPTION
## Summary

User control definitions in `UserSettings.txt` (`[USER CONTROLS]`) silently failed
whenever the action body contained an `=` sign — for example variable assignments
like `step=(%step% + 1)`.

The parser in `get_user_control_settings` split each line on **every** `=`:

```python
d = d.split('=')
```

For a line such as:

```
ADV = CC, 1, 51, step=(%step% + 1) ; 1/PLAY %step%
```

this discarded everything after the second `=`, leaving `new_ctrl_data[3]` as just
`step`. The registered action became `[ADV] step`, which matches nothing and does
nothing. 

## Fix

Limit the split to the first `=` only, so the full action body stays intact:

```python
d = d.split('=', 1)
```

## Impact

- Variable assignments and any other actions containing `=` now work in
  `[USER CONTROLS]` bindings.
- No change in behavior for existing controls without `=` in their action body.