### PR TITLE
Add MSG and MSGHOLD actions for displaying messages in Live's status bar

### DIFF
--- a/ClyphX/ClyphXGlobalActions.py
+++ b/ClyphX/ClyphXGlobalActions.py
@@ -46,6 +46,8 @@ class ClyphXGlobalActions(ControlSurfaceComponent):
         self._tempo_ramp_active = False
         self._tempo_ramp_settings = []
         self._last_beat = -1
+        self._sticky_message = None
+        self._sticky_token = 0
         self.song().add_current_song_time_listener(self.on_time_changed)
         self.song().add_is_playing_listener(self.on_time_changed)
         if self.song().clip_trigger_quantization != 0:
@@ -63,6 +65,8 @@ class ClyphXGlobalActions(ControlSurfaceComponent):
         self.song().remove_is_playing_listener(self.on_time_changed)
         self._tempo_ramp_settings = []
         self._scenes_to_monitor = None
+        self._sticky_message = None
+        self._sticky_token += 1
         self._parent = None
         if IS_LIVE_9:
             ControlSurfaceComponent.disconnect(self)
@@ -126,6 +130,63 @@ class ClyphXGlobalActions(ControlSurfaceComponent):
                 result.append(int(string))
         except: result = []
         return result
+
+
+    def _parse_status_message(self, xclip, args):
+        """ Builds the message to show in the status bar. The message is lower
+        cased by default; text wrapped in quotes keeps its original capitalization. """
+        args = args.replace(u'\u201c', '"').replace(u'\u201d', '"')
+        if not args:
+            return ''
+        if '"' in args:
+            # Recover the original capitalization from the unaltered trigger name
+            try:
+                name = str(xclip.name)
+            except:
+                name = ''
+            name = name.replace(u'\u201c', '"').replace(u'\u201d', '"')
+            start = name.find('"')
+            end = name.find('"', start + 1)
+            if start != -1 and end != -1:
+                return name[start + 1:end]
+            return args.replace('"', '')
+        return args.lower()
+
+
+    def show_status_message(self, track, xclip, ident, args):
+        """ Shows a message in Live's status bar. The message is shown in lower
+        case by default. To preserve capitalization, wrap the message in quotes. """
+        # Cancel any sticky message that is currently being held
+        self._sticky_message = None
+        self._sticky_token += 1
+        message = self._parse_status_message(xclip, args)
+        if message:
+            self._parent.show_message(message)
+
+
+    def hold_status_message(self, track, xclip, ident, args):
+        """ Like MSG, but keeps re-displaying the message so it persists in Live's
+        status bar until another message is shown. Use MSGHOLD OFF to clear it. """
+        if args.strip().upper() == 'OFF':
+            self._sticky_message = None
+            self._sticky_token += 1
+            return
+        message = self._parse_status_message(xclip, args)
+        self._sticky_message = message if message else None
+        self._sticky_token += 1
+        if self._sticky_message is not None:
+            self._repost_sticky_message(self._sticky_token)
+
+
+    def _repost_sticky_message(self, token):
+        """ Re-posts the held status message on a timer until it's replaced or cleared. """
+        if token != self._sticky_token or self._sticky_message is None or self._parent is None:
+            return
+        self._parent.show_message(self._sticky_message)
+        if IS_LIVE_9:
+            self._parent.schedule_message(5, partial(self._repost_sticky_message, token))
+        else:
+            self._parent.schedule_message(5, self._repost_sticky_message, token)
         
         
     def do_variable_assignment(self, track, xclip, ident, args):

--- a/ClyphX/consts.py
+++ b/ClyphX/consts.py
@@ -76,6 +76,8 @@ GLOBAL_ACTIONS = {
     'LOCLOOP' : 'do_locator_loop_action',
     'METRO' : 'set_metronome', 
     'MIDI': 'send_midi_message',
+    'MSG' : 'show_status_message',
+    'MSGHOLD' : 'hold_status_message',
     'OVER' : 'set_overdub',    
     'PIN' : 'set_punch_in',
     'POUT' : 'set_punch_out',

--- a/reference.md
+++ b/reference.md
@@ -105,6 +105,8 @@ For Scene selection, you can use a number, a string with double-quotes or a regu
 | LOOP &lt;x or >x | Move the Arrangement Loop Backward/Forward by x number of beats. | LOOP <4, LOOP >16
 | LOOP RESET | Reset Arrangement Loop Start position to 1.1.1. | -
 | METRO | Toggle, turn on or turn off Metronome. | METRO, METRO ON, METRO OFF
+| MSG x | Show the message x in Live's Status Bar. By default, the message is shown in lower case. To preserve capitalization, wrap the message in quotes. | MSG hello world, MSG "Preserve Caps"
+| MSGHOLD x | Like MSG, but keeps re-displaying the message so it persists in the Status Bar until another message (MSG/MSGHOLD) is shown. Use MSGHOLD OFF to clear it. | MSGHOLD recording, MSGHOLD "Take 1", MSGHOLD OFF
 | MIDI x | x is the MIDI message (of any type/length) to send. | MIDI 144 0 127, MIDI 192 6, MIDI 240 1 2 3 4 247
 | MIDI CC x y z | Send a MIDI Control Change message where x is the Channel (in the range of 1 – 16), y is the Control number (in the range of 0 – 127) and z is the Value (in the range of 0 – 127). | MIDI CC 1 0 127, MIDI CC 16 10 127
 | MIDI NOTE x y z | Send a MIDI Note message where x is the Channel (in the range of 1 – 16), y is the Note number (in the range of 0 – 127) and z is the Velocity (in the range of 0 – 127). This will send a Note message with virtually no length. | MIDI NOTE 1 0 127, MIDI NOTE 16 10 127


### PR DESCRIPTION
## Summary

Adds two new ClyphX global actions for displaying text in Ableton Live's status bar:

- **`MSG`** — shows a one-shot message in the status bar.
- **`MSGHOLD`** — shows a message that persists (re-displays itself) until it's replaced or cleared.

Both actions lower-case the message by default, and preserve the original capitalization when the message is wrapped in quotes.

## Usage

```
[ID] MSG hello world      → shows "hello world"
[ID] MSG "Preserve Caps"  → shows "Preserve Caps"
[ID] MSGHOLD recording    → holds "recording" until replaced/cleared
[ID] MSGHOLD "Take 1"     → holds "Take 1" (caps preserved)
[ID] MSGHOLD OFF          → stops holding the message
```

- Curly/smart quotes (`“ ”`) are normalized to straight quotes, so quoting works even if Live stores smart quotes in the trigger name.
- Running any `MSG` or a new `MSGHOLD` automatically cancels the previously held message.

## Implementation notes

- `show_status_message` (`MSG`) and `hold_status_message` (`MSGHOLD`) are registered in the `GLOBAL_ACTIONS` map in `ClyphX/consts.py`.
- A shared helper `_parse_status_message` handles the lower-case-by-default / quotes-preserve-caps logic. Because ClyphX upper-cases trigger names early in parsing, the original capitalization is recovered from the unaltered `xclip.name`.
- `MSGHOLD` persistence works by re-posting the message on a timer (`_repost_sticky_message` via `schedule_message`). A `_sticky_token` counter guards the loop so only the most recent hold keeps rescheduling; the message and token are reset on `disconnect`.
