### PR TITLE
Refine MSG and MSGHOLD action parsing to prevent incorrect matches

### DIFF
--- a/ClyphX/ClyphXGlobalActions.py
+++ b/ClyphX/ClyphXGlobalActions.py
@@ -145,7 +145,13 @@ class ClyphXGlobalActions(ControlSurfaceComponent):
             except:
                 name = ''
             name = name.replace(u'\u201c', '"').replace(u'\u201d', '"')
-            start = name.find('"')
+            # Anchor the search to after the MSG/MSGHOLD keyword so that quoted
+            # text earlier in the action list is not mistakenly matched.
+            msg_pos = name.upper().rfind('MSGHOLD')
+            if msg_pos == -1:
+                msg_pos = name.upper().rfind('MSG')
+            search_from = msg_pos if msg_pos != -1 else 0
+            start = name.find('"', search_from)
             end = name.find('"', start + 1)
             if start != -1 and end != -1:
                 return name[start + 1:end]


### PR DESCRIPTION
## Fix quoted MSG/MSGHOLD payload parsing in mixed-quote action lists

This change fixes a parsing bug where `MSG`/`MSGHOLD` could display the wrong text when the message payload was quoted and the same action list also contained other quoted strings (such as quoted track names).

Previously, `_parse_status_message` searched for the first quote in the full clip name, so it could incorrectly capture text from an earlier quoted token like `"HiHat"` instead of the intended message payload.

The parser now anchors quote extraction to the `MSGHOLD`/`MSG` token position (using `rfind`) before locating the payload quotes, ensuring the correct quoted message is shown.

### Repro case (fixed)

    [] "HiHat"/PLAY 1 ; UNARM ; "Kick"/ARM ON ; MSGHOLD "Record Kick"

Before: displayed `HiHat`  
After: displays `Record Kick`